### PR TITLE
Fix AMIs with ephemeral drives

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -12,7 +12,7 @@ function mapAMI(raw) {
       acc[key] = value;
       return acc;
     }, {}),
-    blockDeviceMappings: raw.BlockDeviceMappings.map(raw => ({snapshotId: raw.Ebs.SnapshotId})),
+    blockDeviceMappings: raw.BlockDeviceMappings.filter(raw => raw.Ebs).map(raw => ({snapshotId: raw.Ebs.SnapshotId})),
     excluded: false,
     excludeReasons: [],
     included: false,


### PR DESCRIPTION
Had been running into issues with the following AMI:

```
{"Architecture":"x86_64","CreationDate":"2023-07-21T07:17:48.000Z","ImageId":"ami-0571261f2d047e4e6","ImageLocation":"263901223809/hyperenv-github-actions-20230721071434","ImageType":"machine","Public":false,"OwnerId":"263901223809","PlatformDetails":"Linux/UNIX","UsageOperation":"RunInstances","ProductCodes":[],"State":"available","BlockDeviceMappings":[{"DeviceName":"/dev/sda1","Ebs":{"DeleteOnTermination":true,"Iops":3000,"SnapshotId":"snap-0265983223ac52d67","VolumeSize":86,"VolumeType":"gp3","Throughput":125,"Encrypted":false}},{"DeviceName":"/dev/sdb","VirtualName":"ephemeral0"},{"DeviceName":"/dev/sdc","VirtualName":"ephemeral1"}],"EnaSupport":true,"Hypervisor":"xen","Name":"hyperenv-github-actions-20230721071434","RootDeviceName":"/dev/sda1","RootDeviceType":"ebs","SriovNetSupport":"simple","Tags":[],"VirtualizationType":"hvm"}
```