### PR TITLE
feat: Use new AWS API to delete an AMI with snapshots in one shot

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -1,7 +1,7 @@
 import wildcard from 'wildcard';
 import pLimit from 'p-limit';
 import {paginateDescribeLaunchConfigurations} from '@aws-sdk/client-auto-scaling';
-import {DescribeRegionsCommand, paginateDescribeInstances, DescribeLaunchTemplateVersionsCommand, paginateDescribeImages, DeregisterImageCommand, DeleteSnapshotCommand, paginateDescribeLaunchTemplates} from '@aws-sdk/client-ec2';
+import {DescribeRegionsCommand, paginateDescribeInstances, DescribeLaunchTemplateVersionsCommand, paginateDescribeImages, DeregisterImageCommand, paginateDescribeLaunchTemplates} from '@aws-sdk/client-ec2';
 
 function mapAMI(raw) {
   return {
@@ -167,13 +167,8 @@ export async function fetchAMIs(now, ec2, autoscaling, includeName, includeTagKe
 
 export async function deleteAMI(ec2, ami) {
   await ec2.send(new DeregisterImageCommand({
-    ImageId: ami.id
+    ImageId: ami.id,
+    DeleteAssociatedSnapshots: true
   }));
-  console.log(`AMI ${ami.id} deregistered`);
-  for (const blockDevice of ami.blockDeviceMappings) {
-    await ec2.send(new DeleteSnapshotCommand({
-      SnapshotId: blockDevice.snapshotId
-    }));
-    console.log(`snapshot ${blockDevice.snapshotId} of AMI ${ami.id} deleted`);
-  }
+  console.log(`AMI ${ami.id} deregistered and deleted`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-auto-scaling": "3.777.0",
-        "@aws-sdk/client-ec2": "3.777.0",
+        "@aws-sdk/client-auto-scaling": "3.830.0",
+        "@aws-sdk/client-ec2": "3.830.0",
         "argparse": "2.0.1",
         "p-limit": "6.2.0",
         "wildcard": "2.0.1"
@@ -19,12 +19,12 @@
         "aws-amicleaner": "index.js"
       },
       "devDependencies": {
-        "@eslint/js": "9.23.0",
+        "@eslint/js": "9.29.0",
         "aws-sdk-client-mock": "4.1.0",
         "c8": "10.1.3",
-        "eslint": "9.23.0",
-        "globals": "16.0.0",
-        "mocha": "11.1.0"
+        "eslint": "9.29.0",
+        "globals": "16.2.0",
+        "mocha": "11.7.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -153,50 +153,50 @@
       }
     },
     "node_modules/@aws-sdk/client-auto-scaling": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-auto-scaling/-/client-auto-scaling-3.777.0.tgz",
-      "integrity": "sha512-KzedYddiIqy1C56lgv7MSTAKs9F3qpFUSdipn339d3hIBVbOFsF3YgLGm3ouib0Eyz2L4GgOw/VRaeCTxLNJ1A==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-auto-scaling/-/client-auto-scaling-3.830.0.tgz",
+      "integrity": "sha512-morr6KSAiULoQD9zSnAL2ses1LACYqa+tAwbdo9MbrmVkEWijAGhuqXsNz8NciCSTllO9+0ziJxk7CgtDmZlXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-node": "3.777.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-node": "3.830.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
         "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.3",
+        "@smithy/util-waiter": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -204,51 +204,51 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.777.0.tgz",
-      "integrity": "sha512-LX2dxIRCdDDdpwzAGclzHAECDhxp+ca44AVcdFc0v174cJPsPVqK4WevdIefSsHYGqplsC4QFZiHWniUSFFIDg==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.830.0.tgz",
+      "integrity": "sha512-5rPRmw/Q9F9Q8aAaJaQJx0Py7vo9HoFQWyDwFIMK4BRrVVu4DjqZB/fTOmWiZrwGsgAVdCj5CbFPe4lkc1af1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-node": "3.777.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-sdk-ec2": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-node": "3.830.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.826.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
         "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.3",
+        "@smithy/util-waiter": "^4.0.5",
         "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
@@ -258,47 +258,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.777.0.tgz",
-      "integrity": "sha512-0+z6CiAYIQa7s6FJ+dpBYPi9zr9yY5jBg/4/FGcwYbmqWPXwL9Thdtr0FearYRZgKl7bhL3m3dILCCfWqr3teQ==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
+      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -307,20 +307,24 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
-      "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.826.0.tgz",
+      "integrity": "sha512-BGbQYzWj3ps+dblq33FY5tz/SsgJCcXX0zjQlSC07tYvU1jHTUvsefphyig+fY38xZ4wdKjbTop+KUmXUYrOXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.5.3",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -329,15 +333,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
-      "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.826.0.tgz",
+      "integrity": "sha512-DK3pQY8+iKK3MGDdC3uOZQ2psU01obaKlTYhEwNu4VWzgwQL4Vi3sWj4xSWGEK41vqZxiRLq6fOq7ysRI+qEZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -345,20 +349,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
-      "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.826.0.tgz",
+      "integrity": "sha512-N+IVZBh+yx/9GbMZTKO/gErBi/FYZQtcFRItoLbY+6WU+0cSWyZYfkoeOxHmQV3iX9k65oljERIWUmL9x6OSQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -366,23 +370,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.777.0.tgz",
-      "integrity": "sha512-1X9mCuM9JSQPmQ+D2TODt4THy6aJWCNiURkmKmTIPRdno7EIKgAqrr/LLN++K5mBf54DZVKpqcJutXU2jwo01A==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
+      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.777.0",
-        "@aws-sdk/credential-provider-web-identity": "3.777.0",
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-env": "3.826.0",
+        "@aws-sdk/credential-provider-http": "3.826.0",
+        "@aws-sdk/credential-provider-process": "3.826.0",
+        "@aws-sdk/credential-provider-sso": "3.830.0",
+        "@aws-sdk/credential-provider-web-identity": "3.830.0",
+        "@aws-sdk/nested-clients": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -390,22 +394,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.777.0.tgz",
-      "integrity": "sha512-ZD66ywx1Q0KyUSuBXZIQzBe3Q7MzX8lNwsrCU43H3Fww+Y+HB3Ncws9grhSdNhKQNeGmZ+MgKybuZYaaeLwJEQ==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
+      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.775.0",
-        "@aws-sdk/credential-provider-http": "3.775.0",
-        "@aws-sdk/credential-provider-ini": "3.777.0",
-        "@aws-sdk/credential-provider-process": "3.775.0",
-        "@aws-sdk/credential-provider-sso": "3.777.0",
-        "@aws-sdk/credential-provider-web-identity": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/credential-provider-env": "3.826.0",
+        "@aws-sdk/credential-provider-http": "3.826.0",
+        "@aws-sdk/credential-provider-ini": "3.830.0",
+        "@aws-sdk/credential-provider-process": "3.826.0",
+        "@aws-sdk/credential-provider-sso": "3.830.0",
+        "@aws-sdk/credential-provider-web-identity": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -413,16 +417,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
-      "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.826.0.tgz",
+      "integrity": "sha512-kURrc4amu3NLtw1yZw7EoLNEVhmOMRUTs+chaNcmS+ERm3yK0nKjaJzmKahmwlTQTSl3wJ8jjK7x962VPo+zWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -430,18 +434,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.777.0.tgz",
-      "integrity": "sha512-9mPz7vk9uE4PBVprfINv4tlTkyq1OonNevx2DiXC1LY4mCUCNN3RdBwAY0BTLzj0uyc3k5KxFFNbn3/8ZDQP7w==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
+      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.777.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/token-providers": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/client-sso": "3.830.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/token-providers": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -449,16 +453,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.777.0.tgz",
-      "integrity": "sha512-uGCqr47fnthkqwq5luNl2dksgcpHHjSXz2jUra7TXtFOpqvnhOW8qXjoa1ivlkq8qhqlaZwCzPdbcN0lXpmLzQ==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
+      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/nested-clients": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -466,14 +470,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
-      "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
+      "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -481,13 +485,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
-      "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
+      "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -495,14 +499,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
-      "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
+      "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -510,18 +514,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.775.0.tgz",
-      "integrity": "sha512-5xiHVaGUS2fr6GjzHEFWMZsgDQmWY6KjD4rLwpJVO5ZjsrJpxMa9lTozpdhhZoPR9MoSyObz7GqB7B7UavQv7Q==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.826.0.tgz",
+      "integrity": "sha512-qonwFJddYtVTXEj+GGjqHWqlSYDmKI4ZIf7iozNgucBzP5+zdFuyjvdQIAFLAv/joQphGv4P799PK2Elb5ZzpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-format-url": "3.775.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-format-url": "3.821.0",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -529,17 +533,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.775.0.tgz",
-      "integrity": "sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==",
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
+      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@smithy/core": "^3.5.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -547,47 +551,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.777.0.tgz",
-      "integrity": "sha512-bmmVRsCjuYlStYPt06hr+f8iEyWg7+AklKCA8ZLDEJujXhXIowgUIqXmqpTkXwkVvDQ9tzU7hxaONjyaQCGybA==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
+      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.775.0",
-        "@aws-sdk/middleware-host-header": "3.775.0",
-        "@aws-sdk/middleware-logger": "3.775.0",
-        "@aws-sdk/middleware-recursion-detection": "3.775.0",
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/region-config-resolver": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@aws-sdk/util-endpoints": "3.775.0",
-        "@aws-sdk/util-user-agent-browser": "3.775.0",
-        "@aws-sdk/util-user-agent-node": "3.775.0",
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/core": "^3.2.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-retry": "^4.1.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.5.3",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.8",
-        "@smithy/util-defaults-mode-node": "^4.0.8",
-        "@smithy/util-endpoints": "^3.0.2",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -596,16 +600,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
-      "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
+      "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -613,16 +617,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.777.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.777.0.tgz",
-      "integrity": "sha512-Yc2cDONsHOa4dTSGOev6Ng2QgTKQUEjaUnsyKd13pc/nLLz/WLqHiQ/o7PcnKERJxXGs1g1C6l3sNXiX+kbnFQ==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
+      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.777.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/nested-clients": "3.830.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -630,12 +635,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
-      "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
+      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -643,14 +648,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.775.0.tgz",
-      "integrity": "sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==",
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
+      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.2",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-endpoints": "^3.0.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -658,14 +663,14 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.775.0.tgz",
-      "integrity": "sha512-Nw4nBeyCbWixoGh8NcVpa/i8McMA6RXJIjQFyloJLaPr7CPquz7ZbSl0MUWMFVwP/VHaJ7B+lNN3Qz1iFCEP/Q==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.821.0.tgz",
+      "integrity": "sha512-h+xqmPToxDrZ0a7rxE1a8Oh4zpWfZe9oiQUphGtfiGFA6j75UiURH5J3MmGHa/G4t15I3iLLbYtUXxvb1i7evg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -673,9 +678,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
-      "integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
+      "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -685,27 +690,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
-      "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
+      "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.775.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.775.0.tgz",
-      "integrity": "sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==",
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
+      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.775.0",
-        "@aws-sdk/types": "3.775.0",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -720,6 +725,19 @@
         }
       }
     },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
+      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -731,9 +749,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -773,9 +791,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -788,9 +806,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -798,9 +816,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -848,13 +866,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -868,14 +889,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
+      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.15.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -934,9 +968,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1064,12 +1098,12 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
-      "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
+      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1077,15 +1111,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
-      "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
+      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1093,17 +1127,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
+      "integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-stream": "^4.2.2",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1112,15 +1147,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
-      "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
+      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1128,14 +1163,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
-      "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
+      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1144,12 +1179,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
-      "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
+      "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -1159,12 +1194,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
-      "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
+      "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1184,13 +1219,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
-      "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
+      "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1198,18 +1233,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
-      "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.11.tgz",
+      "integrity": "sha512-zDogwtRLzKl58lVS8wPcARevFZNBOOqnmzWWxVe9XiaXU2CADFjvJ9XfNibgkOWs08sxLuSr81NrpY4mgp9OwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/core": "^3.5.3",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-middleware": "^4.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1217,18 +1252,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
-      "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz",
+      "integrity": "sha512-wvIH70c4e91NtRxdaLZF+mbLZ/HcC6yg7ySKUiufL6ESp6zJUSnJucZ309AvG9nqCFHSRB5I6T3Ez1Q9wCh0Ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/service-error-classification": "^4.0.5",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.5",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -1237,12 +1272,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
-      "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
+      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1250,12 +1286,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
-      "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
+      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1263,14 +1299,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
-      "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
+      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1278,15 +1314,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
-      "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
+      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/querystring-builder": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1294,12 +1330,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
-      "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
+      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1307,12 +1343,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
-      "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
+      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1320,12 +1356,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
-      "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
+      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -1334,12 +1370,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
-      "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
+      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1347,24 +1383,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
-      "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.5.tgz",
+      "integrity": "sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0"
+        "@smithy/types": "^4.3.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
-      "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
+      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1372,16 +1408,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
-      "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
+      "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-uri-escape": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -1391,17 +1427,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
-      "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.3.tgz",
+      "integrity": "sha512-xxzNYgA0HD6ETCe5QJubsxP0hQH3QK3kbpJz3QrosBCuIWyEXLR/CO5hFb2OeawEKUxMNhz3a1nuJNN2np2RMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
+        "@smithy/core": "^3.5.3",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1409,9 +1445,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1421,13 +1457,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
-      "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
+      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/querystring-parser": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1498,14 +1534,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
-      "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.19.tgz",
+      "integrity": "sha512-mvLMh87xSmQrV5XqnUYEPoiFFeEGYeAKIDDKdhE2ahqitm8OHM3aSvhqL6rrK6wm1brIk90JhxDf5lf2hbrLbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1514,17 +1550,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
-      "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz",
+      "integrity": "sha512-8tYnx+LUfj6m+zkUUIrIQJxPM1xVxfRBvoGHua7R/i6qAxOMjqR6CpEpDwKoIs1o0+hOjGvkKE23CafKL0vJ9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
-        "@smithy/types": "^4.2.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1532,13 +1568,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
-      "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
+      "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1558,12 +1594,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
-      "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
+      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.2.0",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1571,13 +1607,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
-      "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.5.tgz",
+      "integrity": "sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/service-error-classification": "^4.0.5",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1585,14 +1621,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
-      "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
+      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/types": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",
@@ -1629,13 +1665,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.3.tgz",
-      "integrity": "sha512-JtaY3FxmD+te+KSI2FJuEcfNC9T/DGGVf551babM7fAaXhjJUt7oSYurH1Devxd2+BOSUACCgt3buinx4UnmEA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.5.tgz",
+      "integrity": "sha512-4QvC49HTteI1gfemu0I1syWovJgPvGn7CVUoN9ZFkdvr/cCFkrEL7qNCdx/2eICqDWEGnnr68oMdSIPCLAriSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.2",
-        "@smithy/types": "^4.2.0",
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1643,9 +1679,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1687,9 +1723,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1726,16 +1762,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -1765,20 +1791,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1804,19 +1816,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -1824,27 +1823,14 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browser-stdout": {
@@ -1929,41 +1915,19 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/cliui": {
@@ -2094,9 +2058,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2132,9 +2096,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2179,20 +2143,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
-        "@eslint/config-helpers": "^0.2.0",
-        "@eslint/core": "^0.12.0",
+        "@eslint/config-array": "^0.20.1",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.23.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/js": "9.29.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2203,9 +2167,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2240,9 +2204,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2257,9 +2221,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2270,15 +2234,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2389,19 +2353,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2467,21 +2418,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2527,9 +2463,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2553,9 +2489,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2629,19 +2565,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2673,16 +2596,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2930,29 +2843,29 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-      "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
+      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
-        "chokidar": "^3.5.3",
+        "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -2966,9 +2879,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2976,16 +2889,19 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -3040,16 +2956,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/optionator": {
@@ -3197,18 +3103,12 @@
         "node": ">=16"
       }
     },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      "license": "ISC"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3241,16 +3141,17 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-directory": {
@@ -3295,9 +3196,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3370,6 +3271,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/string-width": {
@@ -3530,9 +3441,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3553,19 +3464,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/tslib": {
@@ -3668,9 +3566,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.2.tgz",
+      "integrity": "sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   },
   "homepage": "https://github.com/widdix/aws-amicleaner#readme",
   "dependencies": {
-    "@aws-sdk/client-auto-scaling": "3.777.0",
-    "@aws-sdk/client-ec2": "3.777.0",
+    "@aws-sdk/client-auto-scaling": "3.830.0",
+    "@aws-sdk/client-ec2": "3.830.0",
     "argparse": "2.0.1",
     "p-limit": "6.2.0",
     "wildcard": "2.0.1"
   },
   "devDependencies": {
-    "@eslint/js": "9.23.0",
+    "@eslint/js": "9.29.0",
     "aws-sdk-client-mock": "4.1.0",
     "c8": "10.1.3",
-    "eslint": "9.23.0",
-    "globals": "16.0.0",
-    "mocha": "11.1.0"
+    "eslint": "9.29.0",
+    "globals": "16.2.0",
+    "mocha": "11.7.0"
   },
   "mocha": {
     "timeout": 10000

--- a/test/lib.js
+++ b/test/lib.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import {mockClient} from 'aws-sdk-client-mock';
 import {fetchRegions, fetchInUseAMIIDs, fetchAMIs, deleteAMI} from '../lib.js';
-import {EC2Client, DescribeRegionsCommand, DescribeInstancesCommand, DescribeLaunchTemplatesCommand, DescribeLaunchTemplateVersionsCommand, DeregisterImageCommand, DeleteSnapshotCommand, DescribeImagesCommand} from '@aws-sdk/client-ec2';
+import {EC2Client, DescribeRegionsCommand, DescribeInstancesCommand, DescribeLaunchTemplatesCommand, DescribeLaunchTemplateVersionsCommand, DeregisterImageCommand, DescribeImagesCommand} from '@aws-sdk/client-ec2';
 import {AutoScalingClient, DescribeLaunchConfigurationsCommand} from '@aws-sdk/client-auto-scaling';
 
 describe('lib', () => {
@@ -552,12 +552,10 @@ describe('lib', () => {
       const ec2 = new EC2Client({});
       const ec2Mock = mockClient(ec2);
       ec2Mock.on(DeregisterImageCommand, {
-        ImageId: 'ami-1'
+        ImageId: 'ami-1',
+        DeleteAssociatedSnapshots: true
       }).resolvesOnce({});
-      ec2Mock.on(DeleteSnapshotCommand, {
-        SnapshotId: 'snap-1'
-      }).resolvesOnce({});
-      await deleteAMI(ec2, {id: 'ami-1', blockDeviceMappings: [{snapshotId: 'snap-1'}]});
+      await deleteAMI(ec2, {id: 'ami-1'});
     });
   });
 });


### PR DESCRIPTION
see https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-ec2-delete-underlying-ebs-snapshots-deregistering-amis/)