### PR TITLE
feat: exclude region

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ A typical confirmation screen:
 Do you want to continue and remove 6 AMIs [y/N] ? : 
 ```
 
+To delete all AMIs in all regions except me-central-1 and me-south-1 where the name starts with amiprefix-:
+```bash
+npx aws-amicleaner --region '*' --exclude-region me-central-1 --exclude-region me-south-1 --include-name 'amiprefix-*'
+```
+
 To delete all AMIs in eu-west-* (eu-west-1, eu-west-2, eu-west-3) tagged with CostCenter=X342-*-1111, are older than 7 days (default), are not the newest 5 images (default), and are not in use (default), run:
 ```bash
 npx aws-amicleaner --region 'eu-west-*' --include-tag-key CostCenter --include-tag-value 'X342-*-1111'
@@ -57,6 +62,8 @@ npx aws-amicleaner --include-name 'amiprefix-*' --exclude-newest 0 --exclude-day
 ```
 -h, --help            show this help message and exit
 --region REGION       The AWS region, e.g. us-east-1, arg can be used more than once, wildcard * supported
+--exclude-region EXCLUDEREGION
+                      Exclude AWS region(s) from the resolved set, e.g. me-central-1, arg can be used more than once, wildcard * supported
 --include-name INCLUDENAME
                       The name that must be present, wildcard * supported
 --include-tag-key INCLUDETAGKEY

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ async function input(query) {
 }
 
 async function run({
-  regions: rawRegions,
+  regions: includeRegions,
+  excludeRegions,
   includeName,
   includeTagKey,
   includeTagValue,
@@ -47,7 +48,7 @@ async function run({
     return autoscaling[region];
   };
 
-  const regions = await fetchRegions(ec2Client('us-east-1'), rawRegions);
+  const regions = await fetchRegions(ec2Client('us-east-1'), includeRegions, excludeRegions);
   const amisPerRegion = await Promise.all([...regions].map(region => 
     fetchAMIs(now, ec2Client(region), autoscalingClient(region), includeName, includeTagKey, includeTagValue, excludeNewest, excludeInUse, excludeDays)
       .then(amis => amis.map(ami => ({
@@ -106,6 +107,9 @@ aws-amicleaner --include-name 'amiprefix-*' --exclude-newest 3 --exclude-days 5 
 To delete all AMIs tagged with CostCenter=X342-*-1111, are older than 7 days (default), are not the newest 5 images (default), and are not in use (default), run:
 aws-amicleaner --include-tag-key CostCenter --include-tag-value 'X342-*-1111'
 
+To delete all AMIs in all regions except me-central-1 and me-south-1:
+aws-amicleaner --region '*' --exclude-region me-central-1 --exclude-region me-south-1 --include-name 'amiprefix-*'
+
 Run the command without confirmation (useful in scripts):
 aws-amicleaner --include-tag-key CostCenter --include-tag-value 'X342-*-1111' --force-delete
 
@@ -114,6 +118,7 @@ aws-amicleaner --include-name 'amiprefix-*' --exclude-newest 0 --exclude-days 0 
 `
   });
   parser.add_argument('--region', {dest: 'regions',  type: 'string', action: 'append', default: [], help: 'The AWS region, e.g. us-east-1, arg can be used more than once, wildcard * supported'});
+  parser.add_argument('--exclude-region', {dest: 'excludeRegions', type: 'string', action: 'append', default: [], help: 'Exclude AWS region(s) from the resolved set, e.g. me-central-1, arg can be used more than once, wildcard * supported'});
   parser.add_argument('--include-name', {dest: 'includeName', type: 'string', help: 'The name that must be present, wildcard * supported'});
   parser.add_argument('--include-tag-key', {dest: 'includeTagKey', type: 'string', help: 'The tag key that must be present'});
   parser.add_argument('--include-tag-value', {dest: 'includeTagValue', type: 'string', help: 'The tag value (for the tag key) that must be present, wildcard * supported'});

--- a/lib.js
+++ b/lib.js
@@ -20,21 +20,43 @@ function mapAMI(raw) {
   };
 }
 
-export async function fetchRegions(ec2, rawRegions) {
+export async function fetchRegions(ec2, includeRegions, excludeRegions = []) {
   const regions = new Set();
+  let allRegionNames = null;
 
-  if (rawRegions.length === 0) {
+  const fetchAllRegionNames = async () => {
+    if (allRegionNames === null) {
+      const {Regions} = await ec2.send(new DescribeRegionsCommand({}));
+      allRegionNames = Regions.map(r => r.RegionName);
+    }
+    return allRegionNames;
+  };
+
+  if (includeRegions.length === 0) {
     regions.add(undefined);
   }
 
-  rawRegions.filter(region => !region.includes('*')).forEach(region => regions.add(region));
+  includeRegions.filter(region => !region.includes('*')).forEach(region => regions.add(region));
 
-  const rawRegionsWithWildcard = rawRegions.filter(region => region.includes('*'));
-  if (rawRegionsWithWildcard.length !== 0) {
-    const {Regions} = await ec2.send(new DescribeRegionsCommand({}));
-    rawRegionsWithWildcard.forEach(rawRegionWithWildcard => {
-      wildcard(rawRegionWithWildcard, Regions.map(r => r.RegionName)).forEach(region => regions.add(region));
+  const includeRegionsWithWildcard = includeRegions.filter(region => region.includes('*'));
+  if (includeRegionsWithWildcard.length !== 0) {
+    const names = await fetchAllRegionNames();
+    includeRegionsWithWildcard.forEach(includeRegionWithWildcard => {
+      wildcard(includeRegionWithWildcard, names).forEach(region => regions.add(region));
     });
+  }
+
+  if (excludeRegions.length > 0) {
+    const resolvedExcludes = new Set();
+    excludeRegions.filter(region => !region.includes('*')).forEach(region => resolvedExcludes.add(region));
+    const excludeRegionsWithWildcard = excludeRegions.filter(region => region.includes('*'));
+    if (excludeRegionsWithWildcard.length !== 0) {
+      const names = await fetchAllRegionNames();
+      excludeRegionsWithWildcard.forEach(excludeRegionWithWildcard => {
+        wildcard(excludeRegionWithWildcard, names).forEach(region => resolvedExcludes.add(region));
+      });
+    }
+    resolvedExcludes.forEach(region => regions.delete(region));
   }
 
   return regions;

--- a/test/lib.js
+++ b/test/lib.js
@@ -46,6 +46,61 @@ describe('lib', () => {
       assert.strictEqual(regions.has('eu-west-2'), true);
       assert.strictEqual(regions.has('eu-west-3'), true);
     });
+    it('exclude exact region', async () => {
+      const ec2 = new EC2Client({});
+      const ec2Mock = mockClient(ec2);
+      ec2Mock.rejects(new Error('not mocked'));
+      ec2Mock.on(DescribeRegionsCommand).resolvesOnce({
+        Regions: [{RegionName: 'eu-west-1'}, {RegionName: 'eu-west-2'}, {RegionName: 'eu-west-3'}]
+      });
+      const regions = await fetchRegions(ec2, ['eu-west-*'], ['eu-west-2']);
+      assert.strictEqual(regions.size, 2);
+      assert.strictEqual(regions.has('eu-west-1'), true);
+      assert.strictEqual(regions.has('eu-west-3'), true);
+    });
+    it('exclude wildcard region', async () => {
+      const ec2 = new EC2Client({});
+      const ec2Mock = mockClient(ec2);
+      ec2Mock.rejects(new Error('not mocked'));
+      ec2Mock.on(DescribeRegionsCommand).resolvesOnce({
+        Regions: [
+          {RegionName: 'eu-west-1'}, {RegionName: 'eu-west-2'}, {RegionName: 'eu-west-3'},
+          {RegionName: 'me-central-1'}, {RegionName: 'me-south-1'},
+          {RegionName: 'us-east-1'}, {RegionName: 'us-east-2'}
+        ]
+      });
+      const regions = await fetchRegions(ec2, ['*'], ['me-*']);
+      assert.strictEqual(regions.size, 5);
+      assert.strictEqual(regions.has('me-central-1'), false);
+      assert.strictEqual(regions.has('me-south-1'), false);
+      assert.strictEqual(regions.has('eu-west-1'), true);
+      assert.strictEqual(regions.has('us-east-1'), true);
+    });
+    it('exclude with no include regions', async () => {
+      const ec2 = new EC2Client({});
+      const ec2Mock = mockClient(ec2);
+      ec2Mock.rejects(new Error('not mocked'));
+      const regions = await fetchRegions(ec2, [], ['me-central-1']);
+      assert.strictEqual(regions.size, 1);
+      assert.strictEqual(regions.has(undefined), true);
+    });
+    it('multiple exclude regions', async () => {
+      const ec2 = new EC2Client({});
+      const ec2Mock = mockClient(ec2);
+      ec2Mock.rejects(new Error('not mocked'));
+      ec2Mock.on(DescribeRegionsCommand).resolvesOnce({
+        Regions: [
+          {RegionName: 'eu-west-1'}, {RegionName: 'eu-west-2'},
+          {RegionName: 'me-central-1'}, {RegionName: 'me-south-1'},
+          {RegionName: 'us-east-1'}
+        ]
+      });
+      const regions = await fetchRegions(ec2, ['*'], ['me-central-1', 'me-south-1']);
+      assert.strictEqual(regions.size, 3);
+      assert.strictEqual(regions.has('eu-west-1'), true);
+      assert.strictEqual(regions.has('eu-west-2'), true);
+      assert.strictEqual(regions.has('us-east-1'), true);
+    });
   });
   describe('fetchInUseAMIIDs', () => {
     it('Launch Configuration', async () => {


### PR DESCRIPTION
Because of the ongoing incident in the `me-central-1` and `me-south-1` region it became necessary for me to run the `aws-amicleaner` in all regions expect `me-central-1` and `me-south-1`. Therefore, I propose to add a new parameter `--exclude-region` allowing to define excludes for regions.